### PR TITLE
Adding a convient no-ref version of the carousel for an easy startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,35 @@ A Pure ReactJS Carousel Component
 npm install nuka-carousel
 ```
 
-###Example
+###Simple Example
+```javascript
+'use strict';
+
+var React = require('react');
+
+var Carousel = require('nuka-carousel');
+
+const App = React.createClass({
+  render() {
+    return (
+      <Carousel>
+        <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide1"/>
+        <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide2"/>
+        <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide3"/>
+        <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide4"/>
+        <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide5"/>
+        <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide6"/>
+      </Carousel>
+    )
+  }
+});
+
+module.exports = App;
+```
+
+But `Carousel` is really just a convenient wrapper on our Carousel surface class that can give you a much more fined grained level of control over presentation.
+
+###Carousel Surface Example
 ```javascript
 'use strict';
 
@@ -22,14 +50,14 @@ const App = React.createClass({
   mixins: [Carousel.ControllerMixin],
   render() {
     return (
-      <Carousel ref="carousel" data={this.setCarouselData.bind(this, 'carousel')}>
+      <Carousel.Surface ref="carousel" data={this.setCarouselData.bind(this, 'carousel')}>
         <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide1"/>
         <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide2"/>
         <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide3"/>
         <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide4"/>
         <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide5"/>
         <img src="http://placehold.it/1000x400/ffffff/c0392b/&text=slide6"/>
-      </Carousel>
+      </Carousel.Surface>
     )
   }
 });

--- a/demo/app.js
+++ b/demo/app.js
@@ -6,11 +6,10 @@ import React from 'react/addons';
 window.React = React;
 
 const App = React.createClass({
-  mixins: [Carousel.ControllerMixin],
   render() {
     return (
       <div style={{width: '50%', margin: 'auto'}}>
-        <Carousel ref="carousel" data={this.setCarouselData.bind(this, 'carousel')}>
+        <Carousel>
           <img src="http://placehold.it/1000x400&text=slide1"/>
           <img src="http://placehold.it/1000x400&text=slide2"/>
           <img src="http://placehold.it/1000x400&text=slide3"/>

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -6,8 +6,8 @@ import decorators from './decorators';
 
 React.initializeTouchEvents(true);
 
-const Carousel = React.createClass({
-  displayName: 'Carousel',
+const Surface = React.createClass({
+  displayName: 'Carousel.Surface',
 
   mixins: [tweenState.Mixin],
 
@@ -475,7 +475,7 @@ const Carousel = React.createClass({
 
 });
 
-Carousel.ControllerMixin = {
+const ControllerMixin = {
   getInitialState() {
     return {
       carousels: {}
@@ -489,5 +489,20 @@ Carousel.ControllerMixin = {
     });
   }
 }
+
+const Carousel = React.createClass({
+  displayName: 'Carousel',
+  mixins: [ControllerMixin],
+  render() {
+    return (
+      <Surface ref="carousel" data={this.setCarouselData.bind(this, 'carousel')} {... this.props}>
+        {this.props.children}
+      </Surface>
+    )
+  }
+});
+
+Carousel.Surface = Surface;
+Carousel.ControllerMixin = ControllerMixin;
 
 export default Carousel;


### PR DESCRIPTION
The data stuff is cool, but could be daunting for someone who just wants to try it out and drop something on the page to see it work. So I turned Carousel into Carousel.Surface and created a thin Carousel component that just wraps it, and sets the props and the kids, but handles the ref stuff.
