### PR TITLE
Prevent default events on next/previous button clicks

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -33,7 +33,7 @@ const removeEvent = function(elem, type, eventHandle) {
   }
 };
 
-const Carousel = React.createClass({
+Carousel = React.createClass({
   displayName: 'Carousel',
 
   mixins: [tweenState.Mixin],

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -9,8 +9,12 @@ const DefaultDecorators = [
         return (
           <button
             style={this.getButtonStyles(this.props.currentSlide === 0)}
-            onClick={this.props.previousSlide}>PREV</button>
+            onClick={this.handleClick}>PREV</button>
         )
+      },
+      handleClick(e) {
+        e.preventDefault();
+        this.props.previousSlide();
       },
       getButtonStyles(disabled) {
         return {
@@ -32,8 +36,12 @@ const DefaultDecorators = [
         return (
           <button
             style={this.getButtonStyles(this.props.currentSlide + this.props.slidesToScroll >= this.props.slideCount)}
-            onClick={this.props.nextSlide}>NEXT</button>
+            onClick={this.handleClick}>NEXT</button>
         )
+      },
+      handleClick(e) {
+        e.preventDefault();
+        this.props.nextSlide();
       },
       getButtonStyles(disabled) {
         return {


### PR DESCRIPTION
This change helps to prevent page refresh when carousel is added inside some <form>. Currently any click on next/previous submits form:

```
...
render() {
   return(
       <form action="/">
         <Carousel>
             ...
        <Carousel>
       </form>
  )
}
```