### PR TITLE
Use translate3d to animate list styles

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -568,18 +568,17 @@ var Carousel = _react2['default'].createClass({
   getListStyles: function getListStyles() {
     var listWidth = this.state.slideWidth * _react2['default'].Children.count(this.props.children);
     var spacingOffset = this.props.cellSpacing * _react2['default'].Children.count(this.props.children);
+    var transform = 'translate3d(' + this.getTweeningValue('left') + 'px, ' + this.getTweeningValue('top') + ', 0)';
     return {
+      transform: transform,
+      WebkitTransform: transform,
       position: 'relative',
       display: 'block',
-      top: this.getTweeningValue('top'),
-      left: this.getTweeningValue('left'),
       margin: this.props.vertical ? this.props.cellSpacing / 2 * -1 + 'px 0px' : '0px ' + this.props.cellSpacing / 2 * -1 + 'px',
       padding: 0,
       height: this.props.vertical ? listWidth + spacingOffset : 'auto',
       width: this.props.vertical ? 'auto' : listWidth + spacingOffset,
       cursor: this.state.dragging === true ? 'pointer' : 'inherit',
-      transform: 'translate3d(0, 0, 0)',
-      WebkitTransform: 'translate3d(0, 0, 0)',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box'
     };

--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -572,6 +572,7 @@ var Carousel = _react2['default'].createClass({
     return {
       transform: transform,
       WebkitTransform: transform,
+      msTransform: 'translate(' + this.getTweeningValue('left') + 'px, ' + this.getTweeningValue('top') + ')',
       position: 'relative',
       display: 'block',
       margin: this.props.vertical ? this.props.cellSpacing / 2 * -1 + 'px 0px' : '0px ' + this.props.cellSpacing / 2 * -1 + 'px',
@@ -594,6 +595,7 @@ var Carousel = _react2['default'].createClass({
       padding: 0,
       transform: 'translate3d(0, 0, 0)',
       WebkitTransform: 'translate3d(0, 0, 0)',
+      msTransform: 'translate(0, 0)',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box'
     };
@@ -648,7 +650,8 @@ var Carousel = _react2['default'].createClass({
             top: 0,
             left: '50%',
             transform: 'translateX(-50%)',
-            WebkitTransform: 'translateX(-50%)'
+            WebkitTransform: 'translateX(-50%)',
+            msTransform: 'translateX(-50%)'
           };
         }
       case 'TopRight':
@@ -666,7 +669,8 @@ var Carousel = _react2['default'].createClass({
             top: '50%',
             left: 0,
             transform: 'translateY(-50%)',
-            WebkitTransform: 'translateY(-50%)'
+            WebkitTransform: 'translateY(-50%)',
+            msTransform: 'translateY(-50%)'
           };
         }
       case 'CenterCenter':
@@ -676,7 +680,8 @@ var Carousel = _react2['default'].createClass({
             top: '50%',
             left: '50%',
             transform: 'translate(-50%,-50%)',
-            WebkitTransform: 'translate(-50%, -50%)'
+            WebkitTransform: 'translate(-50%, -50%)',
+            msTransform: 'translate(-50%, -50%)'
           };
         }
       case 'CenterRight':
@@ -686,7 +691,8 @@ var Carousel = _react2['default'].createClass({
             top: '50%',
             right: 0,
             transform: 'translateY(-50%)',
-            WebkitTransform: 'translateY(-50%)'
+            WebkitTransform: 'translateY(-50%)',
+            msTransform: 'translateY(-50%)'
           };
         }
       case 'BottomLeft':
@@ -704,7 +710,8 @@ var Carousel = _react2['default'].createClass({
             bottom: 0,
             left: '50%',
             transform: 'translateX(-50%)',
-            WebkitTransform: 'translateX(-50%)'
+            WebkitTransform: 'translateX(-50%)',
+            msTransform: 'translateX(-50%)'
           };
         }
       case 'BottomRight':

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.3",
     "phantomjs": "^1.9.18",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
+    "react": "^0.14.3",
+    "react-dom": "^0.14.3",
     "react-hot-loader": "^1.3.0",
     "sinon": "^1.17.1",
     "sinon-chai": "^2.8.0",
@@ -48,6 +48,10 @@
     "url-loader": "^0.5.6",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.0"
+  },
+  "peerDependencies": {
+    "react": "^0.14.3",
+    "react-dom": "^0.14.3"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -532,7 +532,6 @@ const Carousel = React.createClass({
 
   setLeft() {
     this.setState({
-      transform: `translateX(${this.props.vertical ? 0 : this.getTargetLeft()})`,
       left: this.props.vertical ? 0 : this.getTargetLeft(),
       top: this.props.vertical ? this.getTargetLeft() : 0
     })

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -532,6 +532,7 @@ const Carousel = React.createClass({
 
   setLeft() {
     this.setState({
+      transform: `translateX(${this.props.vertical ? 0 : this.getTargetLeft()})`,
       left: this.props.vertical ? 0 : this.getTargetLeft(),
       top: this.props.vertical ? this.getTargetLeft() : 0
     })
@@ -550,19 +551,20 @@ const Carousel = React.createClass({
   getListStyles() {
     var listWidth = this.state.slideWidth * React.Children.count(this.props.children);
     var spacingOffset = this.props.cellSpacing * React.Children.count(this.props.children);
+    var transform = 'translate3d(' +
+      this.getTweeningValue('left') + 'px, ' +
+      this.getTweeningValue('top') + ', 0)'
     return {
+      transform,
+      WebkitTransform: transform,
       position: 'relative',
       display: 'block',
-      top: this.getTweeningValue('top'),
-      left: this.getTweeningValue('left'),
       margin: this.props.vertical ? (this.props.cellSpacing / 2) * -1 + 'px 0px'
                                   : '0px ' + (this.props.cellSpacing / 2) * -1 + 'px',
       padding: 0,
       height: this.props.vertical ? listWidth + spacingOffset : 'auto',
       width: this.props.vertical ? 'auto' : listWidth + spacingOffset,
       cursor: this.state.dragging === true ? 'pointer' : 'inherit',
-      transform: 'translate3d(0, 0, 0)',
-      WebkitTransform: 'translate3d(0, 0, 0)',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box'
     }

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -556,6 +556,9 @@ const Carousel = React.createClass({
     return {
       transform,
       WebkitTransform: transform,
+      msTransform: 'translate(' +
+        this.getTweeningValue('left') + 'px, ' +
+        this.getTweeningValue('top') + ')',
       position: 'relative',
       display: 'block',
       margin: this.props.vertical ? (this.props.cellSpacing / 2) * -1 + 'px 0px'
@@ -579,6 +582,7 @@ const Carousel = React.createClass({
       padding: 0,
       transform: 'translate3d(0, 0, 0)',
       WebkitTransform: 'translate3d(0, 0, 0)',
+      msTransform: 'translate(0, 0)',
       boxSizing: 'border-box',
       MozBoxSizing: 'border-box'
     }
@@ -631,7 +635,8 @@ const Carousel = React.createClass({
           top: 0,
           left: '50%',
           transform: 'translateX(-50%)',
-          WebkitTransform: 'translateX(-50%)'
+          WebkitTransform: 'translateX(-50%)',
+          msTransform: 'translateX(-50%)'
         }
       }
       case 'TopRight': {
@@ -647,7 +652,8 @@ const Carousel = React.createClass({
           top: '50%',
           left: 0,
           transform: 'translateY(-50%)',
-          WebkitTransform: 'translateY(-50%)'
+          WebkitTransform: 'translateY(-50%)',
+          msTransform: 'translateY(-50%)'
         }
       }
       case 'CenterCenter': {
@@ -656,7 +662,8 @@ const Carousel = React.createClass({
           top: '50%',
           left: '50%',
           transform: 'translate(-50%,-50%)',
-          WebkitTransform: 'translate(-50%, -50%)'
+          WebkitTransform: 'translate(-50%, -50%)',
+          msTransform: 'translate(-50%, -50%)'
         }
       }
       case 'CenterRight': {
@@ -665,7 +672,8 @@ const Carousel = React.createClass({
           top: '50%',
           right: 0,
           transform: 'translateY(-50%)',
-          WebkitTransform: 'translateY(-50%)'
+          WebkitTransform: 'translateY(-50%)',
+          msTransform: 'translateY(-50%)'
         }
       }
       case 'BottomLeft': {
@@ -681,7 +689,8 @@ const Carousel = React.createClass({
           bottom: 0,
           left: '50%',
           transform: 'translateX(-50%)',
-          WebkitTransform: 'translateX(-50%)'
+          WebkitTransform: 'translateX(-50%)',
+          msTransform: 'translateX(-50%)'
         }
       }
       case 'BottomRight': {

--- a/test/specs/carousel.spec.js
+++ b/test/specs/carousel.spec.js
@@ -225,7 +225,7 @@ describe('Carousel', function () {
           component,
           'slider-list'
         );
-        expect(slider.props.style.left).to.equal(0);
+        expect(slider.props.style.transform).to.equal('translate3d(0px, 0, 0)');
     });
 
     it('should align to 200 if cellAlign is center', function() {
@@ -242,7 +242,7 @@ describe('Carousel', function () {
         component,
           'slider-list'
         );
-        expect(slider.props.style.left).to.equal(200);
+        expect(slider.props.style.transform).to.equal('translate3d(200px, 0, 0)');
     });
 
     it('should align to 400 if cellAlign is right', function() {
@@ -259,7 +259,7 @@ describe('Carousel', function () {
         component,
           'slider-list'
         );
-        expect(slider.props.style.left).to.equal(400);
+        expect(slider.props.style.transform).to.equal('translate3d(400px, 0, 0)');
     });
 
     it('should set slide width to 200 if cellSpacing is not provided', function() {


### PR DESCRIPTION
The performance when animating left and top properties was really bad in some cases, resulting in a lot of lag. 

This PR changes to animate the translate3d property instead, which is more performant since the browser doesn’t need to repaint on every frame.

Tests are also updated accordingly.