### PR TITLE
Add beforeSlide and afterSlide callback functions to carousel props.

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -79,7 +79,9 @@ var Carousel = _react2['default'].createClass({
     slideWidth: _react2['default'].PropTypes.oneOfType([_react2['default'].PropTypes.string, _react2['default'].PropTypes.number]),
     speed: _react2['default'].PropTypes.number,
     vertical: _react2['default'].PropTypes.bool,
-    width: _react2['default'].PropTypes.string
+    width: _react2['default'].PropTypes.string,
+    beforeSlide: _react2['default'].PropTypes.func,
+    afterSlide: _react2['default'].PropTypes.func
   },
 
   getDefaultProps: function getDefaultProps() {
@@ -97,7 +99,9 @@ var Carousel = _react2['default'].createClass({
       slideWidth: 1,
       speed: 500,
       vertical: false,
-      width: '100%'
+      width: '100%',
+      beforeSlide: function beforeSlide() {},
+      afterSlide: function afterSlide() {}
     };
   },
 
@@ -361,10 +365,14 @@ var Carousel = _react2['default'].createClass({
     if (index >= _react2['default'].Children.count(this.props.children) || index < 0) {
       return;
     }
+
+    this.props.beforeSlide(this.state.currentSlide, index);
+
     this.setState({
       currentSlide: index
     }, function () {
       self.animateSlide();
+      this.props.afterSlide(index);
       self.setExternalData();
     });
   },
@@ -374,12 +382,8 @@ var Carousel = _react2['default'].createClass({
     if (this.state.currentSlide + this.state.slidesToScroll >= _react2['default'].Children.count(this.props.children)) {
       return;
     }
-    this.setState({
-      currentSlide: this.state.currentSlide + this.state.slidesToScroll
-    }, function () {
-      self.animateSlide();
-      self.setExternalData();
-    });
+
+    this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
   },
 
   previousSlide: function previousSlide() {
@@ -387,12 +391,8 @@ var Carousel = _react2['default'].createClass({
     if (this.state.currentSlide - this.state.slidesToScroll < 0) {
       return;
     }
-    this.setState({
-      currentSlide: this.state.currentSlide - this.state.slidesToScroll
-    }, function () {
-      self.animateSlide();
-      self.setExternalData();
-    });
+
+    this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
   },
 
   // Animation

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -60,7 +60,9 @@ const Carousel = React.createClass({
     ]),
     speed: React.PropTypes.number,
     vertical: React.PropTypes.bool,
-    width: React.PropTypes.string
+    width: React.PropTypes.string,
+    beforeSlide: React.PropTypes.func,
+    afterSlide: React.PropTypes.func
   },
 
   getDefaultProps() {
@@ -78,7 +80,9 @@ const Carousel = React.createClass({
       slideWidth: 1,
       speed: 500,
       vertical: false,
-      width: '100%'
+      width: '100%',
+      beforeSlide: function(){},
+      afterSlide: function(){}
     }
   },
 
@@ -353,10 +357,14 @@ const Carousel = React.createClass({
     if (index >= React.Children.count(this.props.children) || index < 0) {
       return;
     }
+
+    this.props.beforeSlide(this.state.currentSlide, index);
+
     this.setState({
       currentSlide: index
     }, function() {
       self.animateSlide();
+      this.props.afterSlide(index);
       self.setExternalData();
     });
   },
@@ -366,12 +374,8 @@ const Carousel = React.createClass({
     if ((this.state.currentSlide + this.state.slidesToScroll) >= React.Children.count(this.props.children)) {
       return;
     }
-    this.setState({
-      currentSlide: this.state.currentSlide + this.state.slidesToScroll
-    }, function() {
-      self.animateSlide();
-      self.setExternalData();
-    });
+
+    this.goToSlide(this.state.currentSlide + this.state.slidesToScroll);
   },
 
   previousSlide() {
@@ -379,12 +383,8 @@ const Carousel = React.createClass({
     if ((this.state.currentSlide - this.state.slidesToScroll) < 0) {
       return;
     }
-    this.setState({
-      currentSlide: this.state.currentSlide - this.state.slidesToScroll
-    }, function() {
-      self.animateSlide();
-      self.setExternalData();
-    });
+
+    this.goToSlide(this.state.currentSlide - this.state.slidesToScroll);
   },
 
   // Animation


### PR DESCRIPTION
I've added hooks to be called before and after the slide changes. This fixes [Issue 39](https://github.com/kenwheeler/nuka-carousel/issues/39) as well as making it behave more like Slick Slider.

Usage:
```
...

handleBeforeSlide(currentSlideIndex, nextSlideIndex) {
    console.log("current slide index", currentSlideIndex);
    console.log("next slide index", nextSlideIndex);
}

handleAfterSlide(currentSlideIndex) {
    console.log("current slide index", currentSlideIndex);
}

render() {
    return (
        ...
        <Carousel
            beforeSlide={this.handleBeforeSlide}
            afterSlide={this.handleAfterSlide} >
            ...
        </Carousel>
    )
}
```