### PR TITLE
Fix Vertical Scrolling on Touch Devices

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -209,12 +209,14 @@ var Carousel = _react2['default'].createClass({
           e.preventDefault();
         }
 
+        var length = self.props.vertical ? Math.round(Math.sqrt(Math.pow(e.touches[0].pageY - self.touchObject.startY, 2))) : Math.round(Math.sqrt(Math.pow(e.touches[0].pageX - self.touchObject.startX, 2)));
+
         self.touchObject = {
           startX: self.touchObject.startX,
           startY: self.touchObject.startY,
           endX: e.touches[0].pageX,
           endY: e.touches[0].pageY,
-          length: Math.round(Math.sqrt(Math.pow(e.touches[0].pageX - self.touchObject.startX, 2))),
+          length: length,
           direction: direction
         };
 

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -205,12 +205,15 @@ Carousel = React.createClass({
           e.preventDefault();
         }
 
+        var length = self.props.vertical ? Math.round(Math.sqrt(Math.pow(e.touches[0].pageY - self.touchObject.startY, 2)))
+                                         : Math.round(Math.sqrt(Math.pow(e.touches[0].pageX - self.touchObject.startX, 2)))
+
         self.touchObject = {
           startX: self.touchObject.startX,
           startY: self.touchObject.startY,
           endX: e.touches[0].pageX,
           endY: e.touches[0].pageY,
-          length: Math.round(Math.sqrt(Math.pow(e.touches[0].pageX - self.touchObject.startX, 2))),
+          length: length,
           direction: direction
         }
 


### PR DESCRIPTION
The `length` calculation in `onTouchMove` was not checking for the presence of the `vertical` property. 

This caused a significant bug when scrolling vertically on touch devices when using `vertical: true`: a user has to swipe **horizontally** to make the carousel transition **vertically**.

This PR fixes the scrolling bug by checking for `vertical` property in `onTouchMove`, and calculating the touch's `length` with `pageY` and `startY` rather than `pageX` and `startX`. A similar conditional already exists for mouse events: https://github.com/kenwheeler/nuka-carousel/blob/master/src/carousel.js#L267-L268, so the behavior there is correct.