### PR TITLE
fix(slideCount): update slide count for async scenarios

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -128,6 +128,9 @@ const Carousel = React.createClass({
   },
 
   componentWillReceiveProps(nextProps) {
+    this.setState({
+      slideCount: nextProps.children.length
+    });
     this.setDimensions();
     if (nextProps.slideIndex !== this.state.currentSlide) {
       this.goToSlide(nextProps.slideIndex);
@@ -543,7 +546,6 @@ const Carousel = React.createClass({
 
     this.setState({
       frameWidth: frameWidth,
-      slideCount: React.Children.count(this.props.children),
       slideWidth: slideWidth,
       slidesToScroll: slidesToScroll,
       left: this.props.vertical ? 0 : this.getTargetLeft(),


### PR DESCRIPTION
In order to handle async scenarios, update slideCount based on props.children.length, as the content may not have loaded into the DOM yet. 