### PR TITLE
Use the correct props

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -131,7 +131,7 @@ const Carousel = React.createClass({
     this.setState({
       slideCount: nextProps.children.length
     });
-    this.setDimensions();
+    this.setDimensions(nextProps);
     if (nextProps.slideIndex !== this.state.currentSlide) {
       this.goToSlide(nextProps.slideIndex);
     }
@@ -506,7 +506,9 @@ const Carousel = React.createClass({
     });
   },
 
-  setDimensions() {
+  setDimensions(props) {
+    props = props || this.props;
+
     var self = this,
       slideWidth,
       slidesToScroll,
@@ -516,43 +518,43 @@ const Carousel = React.createClass({
       frameHeight,
       slideHeight;
 
-    slidesToScroll = this.props.slidesToScroll;
+    slidesToScroll = props.slidesToScroll;
     frame = this.refs.frame;
     firstSlide = frame.childNodes[0].childNodes[0];
     if (firstSlide) {
       firstSlide.style.height = 'auto';
-      slideHeight = firstSlide.offsetHeight * this.props.slidesToShow;
+      slideHeight = firstSlide.offsetHeight * props.slidesToShow;
     } else {
       slideHeight = 100;
     }
 
-    if (typeof this.props.slideWidth !== 'number') {
-      slideWidth = parseInt(this.props.slideWidth);
+    if (typeof props.slideWidth !== 'number') {
+      slideWidth = parseInt(props.slideWidth);
     } else {
-      if (this.props.vertical) {
-        slideWidth = (slideHeight / this.props.slidesToShow) * this.props.slideWidth;
+      if (props.vertical) {
+        slideWidth = (slideHeight / props.slidesToShow) * props.slideWidth;
       } else {
-        slideWidth = (frame.offsetWidth / this.props.slidesToShow) * this.props.slideWidth;
+        slideWidth = (frame.offsetWidth / props.slidesToShow) * props.slideWidth;
       }
     }
 
-    if (!this.props.vertical) {
-      slideWidth -= this.props.cellSpacing * ((100 - (100 / this.props.slidesToShow)) / 100);
+    if (!props.vertical) {
+      slideWidth -= props.cellSpacing * ((100 - (100 / props.slidesToShow)) / 100);
     }
 
-    frameHeight = slideHeight + ((this.props.cellSpacing / 2) * (this.props.slidesToShow - 1));
-    frameWidth = this.props.vertical ? frameHeight : frame.offsetWidth;
+    frameHeight = slideHeight + ((props.cellSpacing / 2) * (props.slidesToShow - 1));
+    frameWidth = props.vertical ? frameHeight : frame.offsetWidth;
 
-    if (this.props.slidesToScroll === 'auto') {
-      slidesToScroll = Math.floor(frameWidth / (slideWidth + this.props.cellSpacing));
+    if (props.slidesToScroll === 'auto') {
+      slidesToScroll = Math.floor(frameWidth / (slideWidth + props.cellSpacing));
     }
 
     this.setState({
       frameWidth: frameWidth,
       slideWidth: slideWidth,
       slidesToScroll: slidesToScroll,
-      left: this.props.vertical ? 0 : this.getTargetLeft(),
-      top: this.props.vertical ? this.getTargetLeft() : 0
+      left: props.vertical ? 0 : this.getTargetLeft(),
+      top: props.vertical ? this.getTargetLeft() : 0
     }, function() {
       self.setLeft()
     });


### PR DESCRIPTION
Issue: `setDimension` uses stale props when new set of props are available (e.g new settings on resize).

This PR passes the `nextProps` to `setDimension`, so that correct props are used while doing carousel calculations.

e.g I have a Responsive carousel which passes the different settings for different widths.
`@1023px` `slidesToShow = 3` and `@1024` `slidesToShow=4`

**Before**
![before-nuka-fix](https://cloud.githubusercontent.com/assets/3193886/15365401/c1cdb4ba-1d3d-11e6-93a9-e5c5e82bd2b6.gif)


**after**
![after-nuka-fix](https://cloud.githubusercontent.com/assets/3193886/15365476/fbf73a6c-1d3d-11e6-8b08-f151785ad5a5.gif)

/cc @kenwheeler 