### PR TITLE
Fix the currentSlide reset on re-rendering of carousel

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -143,7 +143,7 @@ const Carousel = React.createClass({
       slideCount: nextProps.children.length
     });
     this.setDimensions(nextProps);
-    if (nextProps.slideIndex !== this.state.currentSlide) {
+    if (nextProps.slideIndex && nextProps.slideIndex !== this.state.currentSlide) {
       this.goToSlide(nextProps.slideIndex);
     }
     if (this.props.autoplay !== nextProps.autoplay) {


### PR DESCRIPTION
This PR fixes an issue when we don't pass a `slideIndex` prop ( by default is 0 ), any subsequent re-render will cause currentSlide to switch back to `0`.

**Before**
![nuka-carousel-before](https://cloud.githubusercontent.com/assets/3193886/16308825/1b83304a-3984-11e6-9071-96a23e8b8c99.gif)

**After**
![nuka-carousel-after](https://cloud.githubusercontent.com/assets/3193886/16308824/1b7f9eda-3984-11e6-91de-7e7fc29b2294.gif)

/cc @kenwheeler 

