### PR TITLE
Fix condition for goToSlide on props receive

### DIFF
--- a/lib/carousel.js
+++ b/lib/carousel.js
@@ -150,7 +150,7 @@ var Carousel = _react2['default'].createClass({
       slideCount: nextProps.children.length
     });
     this.setDimensions(nextProps);
-    if (nextProps.slideIndex && nextProps.slideIndex !== this.state.currentSlide) {
+    if (typeof nextProps.slideIndex === 'number' && nextProps.slideIndex !== this.state.currentSlide) {
       this.goToSlide(nextProps.slideIndex);
     }
     if (this.props.autoplay !== nextProps.autoplay) {


### PR DESCRIPTION
nextProps.slideIndex may sometimes be equal to 0, which results in falsy value.
nextProps.slideIndex should be tested as a number instead.