### PR TITLE
Update condition for gotoSlide in componentWillRecieveProps

### DIFF
--- a/src/carousel.js
+++ b/src/carousel.js
@@ -143,7 +143,7 @@ const Carousel = React.createClass({
       slideCount: nextProps.children.length
     });
     this.setDimensions(nextProps);
-    if (nextProps.slideIndex && nextProps.slideIndex !== this.state.currentSlide) {
+    if (this.props.slideIndex !== nextProps.slideIndex && nextProps.slideIndex !== this.state.currentSlide) {
       this.goToSlide(nextProps.slideIndex);
     }
     if (this.props.autoplay !== nextProps.autoplay) {


### PR DESCRIPTION
Fixes re-render reset of carousel state. This is improvement over #108 to allow `nextProps.slideIndex = 0`.

Only trigger `gotoSlide` in componentWillRecieveProps when
```
1. There is actual change in `props.SlideIndex` and `nextProps.slideIndex`
2. nextProps.SlideIndex is not the currentSlide. 
```

/cc @kenwheeler 
