### PR TITLE
[MINOR] Upgrade object-assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "exenv": "^1.2.0",
-    "object-assign": "^4.0.1",
+    "object-assign": "^4.1.0",
     "kw-react-tween-state": "^0.1.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR upgrades `object-assign` to `4.1.0`, the latest version.